### PR TITLE
Fix README usage section and add Qari adapter inference example

### DIFF
--- a/inference.ipynb
+++ b/inference.ipynb
@@ -1,0 +1,100 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "68f801cb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from transformers import Qwen2VLForConditionalGeneration, AutoProcessor\n",
+    "from peft import PeftModel\n",
+    "from qwen_vl_utils import process_vision_info"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9680ed1d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "BASE_MODEL = \"Qwen/Qwen2-VL-2B-Instruct\"\n",
+    "ADAPTER_MODEL = \"NAMAA-Space/Qari-OCR-0.2.2.1-VL-2B-Instruct\" "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7d7c5ab4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "base_model = Qwen2VLForConditionalGeneration.from_pretrained(\n",
+    "      BASE_MODEL,\n",
+    "      torch_dtype=\"auto\",\n",
+    "      device_map=\"auto\"\n",
+    ")\n",
+    "\n",
+    "model = PeftModel.from_pretrained(base_model, ADAPTER_MODEL)\n",
+    "\n",
+    "processor = AutoProcessor.from_pretrained(BASE_MODEL)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90989f0d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "IMAGE_PATH = \"path/image.jpg\"\n",
+    "\n",
+    "prompt = \"Below is the image of one page of a document, as well as some raw textual content that was previously extracted for it. Just return the plain text representation of this document as if you were reading it naturally. Do not hallucinate.\"\n",
+    "max_tokens = 2000\n",
+    "\n",
+    "messages = [\n",
+    "    {\n",
+    "        \"role\": \"user\",\n",
+    "        \"content\": [\n",
+    "            {\"type\": \"image\", \"image\": f\"file://{IMAGE_PATH}\"},\n",
+    "            {\"type\": \"text\", \"text\": prompt},\n",
+    "        ],\n",
+    "    }\n",
+    "  ]\n",
+    "text = processor.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)\n",
+    "image_inputs, video_inputs = process_vision_info(messages)\n",
+    "inputs = processor(\n",
+    "      text=[text],\n",
+    "      images=image_inputs,\n",
+    "      videos=video_inputs,\n",
+    "      padding=True,\n",
+    "      return_tensors=\"pt\",\n",
+    ").to(\"cuda\")\n",
+    "\n",
+    "generated_ids = model.generate(**inputs, max_new_tokens=max_tokens)\n",
+    "generated_ids_trimmed = [\n",
+    "      out_ids[len(in_ids):] for in_ids, out_ids in zip(inputs.input_ids, generated_ids)\n",
+    "]\n",
+    "output_text = processor.batch_decode(\n",
+    "      generated_ids_trimmed, skip_special_tokens=True, clean_up_tokenization_spaces=False\n",
+    ")[0]\n",
+    "\n",
+    "print(\"OCR Output:\\n\", output_text)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
**Problem:**

- In the README usage section, the src variable was undeclared, which could cause errors when running the example.
- The inference example only ran the base model without the Qari adapters.

**What I fixed / added:**

Updated the README usage section to:
      Fix the src variable bug.
      Add logic to use the Qari adapters with the base model for inference.

Added a new notebook that contains the inference function for quick testing with the Qari adapter.
Ensured users can run inference immediately without additional setup.